### PR TITLE
Clean up jpg to tfr pipeline

### DIFF
--- a/et_util/custom_loss.py
+++ b/et_util/custom_loss.py
@@ -3,19 +3,15 @@ import os
 import numpy as np
 
 
-"""Defines a custom loss function that calculates a weighted Euclidean distance between two sets of points. 
+"""Custom loss function that calculates a weighted Euclidean distance between two sets of points. 
 
-The units of the points is originally percentage of the screen, but those scales are different between the x and y axes. 
-The weighting multiplies the x-coordinate of each input by 1.778 (derived from the 16:9 aspect ratio of most laptops) to match the scale of the y-axis. 
-Finally, to retain interpretability, the distances are normalized to the diagonal such that the maximum distance between two points (corner to corner) is 100. 
-A normalized_loss value of 50 would be equal to the distance from a corner to the center of the screen. 
+Weighting multiplies the x-coordinate of each input by 1.778 (derived from the 16:9 aspect ratio of most laptops) to match the scale of the y-axis. 
+For interpretability, the distances are normalized to the diagonal such that the maximum distance between two points (corner to corner) is 100. 
 
-Parameters:
-y_true (tensor): A tensor of shape (2,) containing ground-truth x- and y- coordinates
-y_pred (tensor): - A tensor of shape (2,) containing predicted x- and y- coordinates
+:param y_true (tensor): A tensor of shape (2,) containing ground-truth x- and y- coordinates
+:param y_pred (tensor): A tensor of shape (2,) containing predicted x- and y- coordinates
 
-Returns:
-Tensor:A tensor of shape (1,) with the weighted and normalized euclidean distances between the points in y_true and y_pred. 
+:returns: A tensor of shape (1,) with the weighted and normalized euclidean distances between the points in y_true and y_pred. 
 """
 
 

--- a/et_util/dataset_utils.py
+++ b/et_util/dataset_utils.py
@@ -234,8 +234,11 @@ def parse_tfr_element_mediapipe(element):
 
 
 def parse_tfr_element_jpg(element):
-    """Process function that parses a tfr element in a raw dataset for get_dataset function. 
+    """Process function that parses a tfr element in a raw dataset for get_dataset function.
     Gets raw image, image height, image width, subject id, and xy labels.
+
+    :param tfr element in raw dataset
+    :return raw image, label, subject_id
     """
 
     data_structure = {
@@ -257,6 +260,6 @@ def parse_tfr_element_jpg(element):
     subject_id = content['subject_id']
 
     image = tf.io.decode_jpeg(raw_image)
-    image = tf.reshape(image, shape=(640, 480, 3))
+    image = tf.reshape(image, shape=(height, width, depth))
 
     return image, label, subject_id

--- a/et_util/dataset_utils.py
+++ b/et_util/dataset_utils.py
@@ -233,11 +233,9 @@ def parse_tfr_element_mediapipe(element):
     return feature, label, subject_id
 
 
-def parse_tfr_element(element):
-    """
-    Process function that parses a tfr element in a raw dataset for
-    get_dataset function. Gets raw image, image height, image width,
-    subject id, and xy labels.
+def parse_tfr_element_jpg(element):
+    """Process function that parses a tfr element in a raw dataset for get_dataset function. 
+    Gets raw image, image height, image width, subject id, and xy labels.
     """
 
     data_structure = {

--- a/et_util/dataset_utils.py
+++ b/et_util/dataset_utils.py
@@ -173,6 +173,7 @@ def process_one_file(in_path: str, file_name: str, process):
 
 def process_tfr_to_tfds(directory_path,
                         process,
+                        filter_imgs=False,
                         train_split=0.8,
                         val_split=0.1,
                         test_split=0.1):
@@ -183,6 +184,7 @@ def process_tfr_to_tfds(directory_path,
     :param directory_path: path of directory containing tfrecords files. 
     Make sure to include / at end.
     :param process: process function that corresponds to shape of data
+    :param filter_imgs: True if images should all be of shape=(480,640,3), False otherwise
     :return: parsed tensorflow dataset
     """
     assert (train_split + val_split + test_split) == 1
@@ -192,7 +194,10 @@ def process_tfr_to_tfds(directory_path,
 
     dataset = tf.data.TFRecordDataset(file_paths)
     dataset = dataset.map(process)
-
+    if filter_imgs == True:
+      dataset = dataset.filter(filter_img_dims)
+      dataset = dataset.map(lambda element, label, subject_id: (tf.reshape(element, (480, 640, 3)), label, subject_id))
+  
     ds_size = 0
     for element in dataset:
         ds_size += 1
@@ -264,3 +269,11 @@ def parse_tfr_element_jpg(element):
     image = tf.reshape(image, shape=(height, width, depth))
 
     return image, label, subject_id
+
+
+def filter_img_dims(image, label, subject_id):
+  """Helper function for process_tfr_to_tfds which filters out any images that do not have shape=(480,640, 3)."""
+  if (tf.math.reduce_any(tf.math.not_equal(tf.shape(image), [480, 640, 3]))):
+    return False
+  else:
+    return True

--- a/et_util/dataset_utils.py
+++ b/et_util/dataset_utils.py
@@ -236,7 +236,7 @@ def parse_tfr_element_mediapipe(element):
 def parse_tfr_element_jpg(element):
     """Process function that parses a tfr element in a raw dataset for process_tfr_to_tfds.
     Gets raw image, image height, image width, subject id, and xy-coordinate labels.
-    Use for data generated with make_single_example_image.
+    Use for data generated with make_single_example_jpg.
 
     :param tfr element in raw dataset
     :return raw image, label(x, y), subject_id

--- a/et_util/dataset_utils.py
+++ b/et_util/dataset_utils.py
@@ -234,11 +234,12 @@ def parse_tfr_element_mediapipe(element):
 
 
 def parse_tfr_element_jpg(element):
-    """Process function that parses a tfr element in a raw dataset for get_dataset function.
-    Gets raw image, image height, image width, subject id, and xy labels.
+    """Process function that parses a tfr element in a raw dataset for process_tfr_to_tfds.
+    Gets raw image, image height, image width, subject id, and xy-coordinate labels.
+    Use for data generated with make_single_example_image.
 
     :param tfr element in raw dataset
-    :return raw image, label, subject_id
+    :return raw image, label(x, y), subject_id
     """
 
     data_structure = {

--- a/et_util/tfrecord_processing.py
+++ b/et_util/tfrecord_processing.py
@@ -122,3 +122,17 @@ def make_single_example_jpg(image_path, face_mesh):
   }
 
   return feature_description
+
+def remove_subject_tfrecords(directory, subject_ids):
+  """Helper function that removes TFRecords files based on a list of subject ids. 
+
+  :param directory: directory with TFRecord files to be filtered
+  :param subject_ids: list of subject ids
+  """
+
+  filenames = [subject_id + '.tfrecords' for subject_id in subject_ids]
+  for filename in os.listdir(directory):
+      if filename in filenames:
+          file_path = os.path.join(directory, filename)
+          os.remove(file_path)
+          print(f"Removed file: {file_path}")

--- a/et_util/tfrecord_processing.py
+++ b/et_util/tfrecord_processing.py
@@ -102,9 +102,9 @@ def make_single_example_mediapipe(image_path, face_mesh):
     return {'landmarks': tf.train.Feature(bytes_list=tf.train.BytesList(value=[lm_arr.numpy()]))}
        
 def make_single_example_jpg(image_path, face_mesh):
-  """Converts a directory of jpg files to a directory of TFRecord files with one file per unique subject. In addition to subject id and labels, TFRecord files include image height, image width, and raw image array.
+  """Converts a directory of jpg files to a directory of TFRecord files with one file per unique subject. In addition to subject id and labels, TFRecord files include image width, image height, and raw image array.
 
-  :param image_path: directory of jpeg files.
+  :param image_path: directory of jpeg files
   :param face_mesh: empty variable needed to integrate with process_jpg_to_tfr
   """
 
@@ -116,15 +116,15 @@ def make_single_example_jpg(image_path, face_mesh):
 
   # Feature description of image to use when parsing
   feature_description = {
-    'height': tf.train.Feature(int64_list=tf.train.Int64List(value=[int(image_shape[0])])),
     'width': tf.train.Feature(int64_list=tf.train.Int64List(value=[int(image_shape[1])])),
+    'height': tf.train.Feature(int64_list=tf.train.Int64List(value=[int(image_shape[0])])),
     'raw_image': tf.train.Feature(bytes_list=tf.train.BytesList(value=[image.numpy()]))
   }
 
   return feature_description
 
 def remove_subject_tfrecords(directory, subject_ids):
-  """Helper function that removes TFRecords files based on a list of subject ids. 
+  """Function that removes TFRecords files based on a list of subject ids. 
 
   :param directory: directory with TFRecord files to be filtered
   :param subject_ids: list of subject ids

--- a/et_util/tfrecord_processing.py
+++ b/et_util/tfrecord_processing.py
@@ -101,7 +101,7 @@ def make_single_example_mediapipe(image_path, face_mesh):
     
     return {'landmarks': tf.train.Feature(bytes_list=tf.train.BytesList(value=[lm_arr.numpy()]))}
        
-def make_single_example_image(image_path, face_mesh):
+def make_single_example_jpg(image_path, face_mesh):
   """Converts a directory of jpg files to a directory of TFRecord files with one file per unique subject. In addition to subject id and labels, TFRecord files include image height, image width, and raw image array.
 
   :param image_path: directory of jpeg files.

--- a/et_util/tfrecord_processing.py
+++ b/et_util/tfrecord_processing.py
@@ -101,106 +101,24 @@ def make_single_example_mediapipe(image_path, face_mesh):
     
     return {'landmarks': tf.train.Feature(bytes_list=tf.train.BytesList(value=[lm_arr.numpy()]))}
        
+def make_single_example_image(image_path, face_mesh):
+  """Converts a directory of jpeg files to a directory of TFRecord files with one file per unique subject id. In addition to subject id and labels, TFRecord files include image height, image width, and raw image array. 
 
-def parse_filename(filename):
-    """Helper function for write_images_to_tf_records that parses the filename
-    into subject ID, x-coordinate, and y-coordinate.
+  :param image_path: directory of jpeg files. 
+  :param face_mesh: empty variable needed to integrate with process_jpg_to_tfr
+  """
 
-    :param filename: Path to an image file.
-    """
+  # read the JPEG source file into a tf.string
+  image = tf.io.read_file(image_path)
 
-    splitname = os.path.splitext(os.path.basename(filename))[0].rsplit('.', 1)[0].split("_")
-    subject_id = splitname[0]
-    x = float(splitname[1])
-    y = float(splitname[2])
-    return {"subject_id": subject_id, "x": x, "y": y}
+  # get the shape of the image from the JPEG file header
+  image_shape = tf.io.extract_jpeg_shape(image, output_type=tf.dtypes.int64, name=None)
 
-def filter_files(all_files):
-    """Helper function for write_images_to_tf_records that filters out
-    a list of unwanted subjects. Currently used to filter out subjects that
-    do not have 480x640 video resolutions.
+  # Feature description of image to use when parsing
+  feature_description = {
+    'height': tf.train.Feature(int64_list=tf.train.Int64List(value=[int(image_shape[0])])),
+    'width': tf.train.Feature(int64_list=tf.train.Int64List(value=[int(image_shape[1])])),
+    'raw_image': tf.train.Feature(bytes_list=tf.train.BytesList(value=[image.numpy()]))
+  }
 
-    :param all_files: List of file names.
-    """
-
-    # list of excluded subjects (from R script)
-    exclude_subjects = ["292x6vxf", "65vwsgbt", "9l9gtnv6", "bqmax27b", "p4h9ljon", "vu8fuh1d", "w2vypg1l"]
-
-    filtered_list = [file for file in all_files if not any(partial_name in file for partial_name in exclude_subjects)]
-
-    return filtered_list
-
-
-def _bytes_feature(value):
-    """Returns a bytes_list from a string / byte."""
-    if isinstance(value, type(tf.constant(0))):  # if value is a tensor
-        value = value.numpy()  # get the value of the tensor
-    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
-
-
-def _float_feature(value):
-    """Returns a float_list from a float / double."""
-    return tf.train.Feature(float_list=tf.train.FloatList(value=[value]))
-
-
-def _int64_feature(value):
-    """Returns an int64_list from a bool / enum / int / uint."""
-    return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
-
-
-def write_images_to_tfrecords(in_path: str,
-                              out_path: str):
-    """Converts a directory of jpeg files to a directory of TFRecord files
-    with one TFRecord per unique subject id. Each TFRecord contains features
-    extracted from filename.
-
-    :param in_path: directory of jpeg files
-    :param out_path: directory where tfrecord files will go
-    """
-
-    # create list of jpg files
-    all_files = os.listdir(in_path)
-
-    # filter any unwanted subjects
-    filtered_files = filter_files(all_files)
-
-    # Dictionary to store TFRecord writers by subject ID
-    subject_records = {}
-
-    for filename in filtered_files:
-
-        file_features = parse_filename(os.path.join(in_path, filename))
-        subject_id = file_features['subject_id']
-
-        # Create a new TFRecord writer if subject ID is new
-        if subject_id not in subject_records:
-            tfrecord_path = os.path.join(out_path, f"{subject_id}.tfrecords")
-            subject_records[subject_id] = tf.io.TFRecordWriter(tfrecord_path)
-
-        # read the JPEG source file into a tf.string
-        image = tf.io.read_file(os.path.join(in_path, filename))
-
-        # get the shape of the image from the JPEG file header
-        image_shape = tf.io.extract_jpeg_shape(image, output_type=tf.dtypes.int64, name=None)
-
-        # Feature description of image to use when parsing
-        feature_description = {
-            'height': _int64_feature(image_shape[0]),
-            'width': _int64_feature(image_shape[0]),
-            'subject_id': _int64_feature(int(file_features['subject_id'], 36)),
-            'raw_image': _bytes_feature(image),
-            'x': _float_feature(file_features['x']),
-            'y': _float_feature(file_features['y'])
-        }
-
-        # Parse image using data structure
-        example = tf.train.Example(features=tf.train.Features(feature=feature_description))
-
-        # Write file to TFRecord file with matching subject ID
-        subject_records[subject_id].write(example.SerializeToString())
-
-    # Close all the TFRecord writers
-    for writer in subject_records.values():
-        writer.close()
-
-    print(f"Wrote {len(filtered_files)} images to TFRecords")
+  return feature_description

--- a/et_util/tfrecord_processing.py
+++ b/et_util/tfrecord_processing.py
@@ -102,9 +102,9 @@ def make_single_example_mediapipe(image_path, face_mesh):
     return {'landmarks': tf.train.Feature(bytes_list=tf.train.BytesList(value=[lm_arr.numpy()]))}
        
 def make_single_example_image(image_path, face_mesh):
-  """Converts a directory of jpeg files to a directory of TFRecord files with one file per unique subject id. In addition to subject id and labels, TFRecord files include image height, image width, and raw image array. 
+  """Converts a directory of jpg files to a directory of TFRecord files with one file per unique subject. In addition to subject id and labels, TFRecord files include image height, image width, and raw image array.
 
-  :param image_path: directory of jpeg files. 
+  :param image_path: directory of jpeg files.
   :param face_mesh: empty variable needed to integrate with process_jpg_to_tfr
   """
 


### PR DESCRIPTION
1. Cleaned up the jpg to tfr to tfds pipeline. You can now filter for image shape=(640, 480, 3) in the process_tfr_to_tfds function. 
2. Reordered variables so image shape is now the standard (width, height, channels) format. 
3. Added pydocs for the normalized weighted euclidean distance loss function
4. Added a a function to remove TFRecord files based on subject ID. This is if we have future filtering criteria based on metadata.