### PR TITLE
Add eye images pipeline functions

### DIFF
--- a/et_util/tfrecord_processing.py
+++ b/et_util/tfrecord_processing.py
@@ -165,7 +165,7 @@ def make_single_example_landmarks_and_jpg(image_path, face_mesh):
 
 def make_single_example_landmarks_and_eyes(image_path, face_mesh):
   """Converts jpg file to a dictionary to be used in process_jpg_to_tfr. 
-  In addition to subject id and labels, TFRecord files include eye image width and height, 
+  In addition to subject id and labels, TFRecord files include eye image widths and heights, 
   and raw left and right eye image arrays. Also includes mediapipe landmarks.
 
   feature_description = {landmarks, left_width, right_width, left_height, right_height, left_eye, right_eye}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "et_util"
-version = "0.1.46"
+version = "0.1.47"
 authors = [
     { name="me", email="example@gmail.com" },
 ]


### PR DESCRIPTION
I added two new pipeline helper functions. make_single_example_landmarks_and_eyes is used to make a dataset of tfrecord files that include eye image data. parse_tfr_element_eyes_and_mediapipe is used to extract the eye image dataset.